### PR TITLE
fix error on missing source

### DIFF
--- a/.changeset/clever-colts-trade.md
+++ b/.changeset/clever-colts-trade.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/ts-json-schema-transformer": patch
+---
+
+handle missing source files

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,33 @@
 import type { JSONSchemaType, ValidateFunction } from "ajv";
 
+/**
+ * Get the JSON schema for the provided type
+ * @transformer ts-json-schema-transformer
+ */
 export function getSchema<T>(): JSONSchemaType<T> {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }
 
+/**
+ * Get a validator for the provided type
+ * @transformer ts-json-schema-transformer
+ */
 export function getValidator<T>(): ValidateFunction<T> {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }
 
+/**
+ * Get a mock object for the provided type
+ * @transformer ts-json-schema-transformer
+ */
 export function getMockObject<T>(): T {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }
 
+/**
+ * Assert that an object is valid according to the provided type
+ * @transformer ts-json-schema-transformer
+ */
 export function assertValid<T = never, U extends T = T>(_obj: unknown): asserts _obj is U {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }

--- a/src/transformers/call-transformer.ts
+++ b/src/transformers/call-transformer.ts
@@ -1,14 +1,10 @@
-import * as path from "path";
 import ts from "typescript";
 import { IProject } from "../project.js";
 import { AssertValidTransformer } from "./assert-valid-transformer.js";
 import { GetMockObjectTransformer } from "./get-mock-object-transformer";
 import { GetSchemaTransformer } from "./get-schema-transformer.js";
+import { hasTransformMarker } from "./utils";
 import { ValidateTransformer } from "./validate-transformer.js";
-
-const LIB_PATHS = [
-  path.join("ts-json-schema-transformer", "dist"),
-];
 
 export abstract class CallTransformer {
   public static transform(project: IProject, expression: ts.CallExpression): ts.Node {
@@ -17,16 +13,16 @@ export abstract class CallTransformer {
     }
 
     const declaration: ts.Declaration | undefined = project.checker.getResolvedSignature(expression)?.declaration;
-    if (!declaration) return expression;
+    if (declaration == null) return expression;
+    if (!ts.isFunctionDeclaration(declaration)) return expression;
+    const name = declaration?.name?.getText();
+    if (name == null) return expression;
 
-    const file: string = path.resolve(declaration.getSourceFile().fileName);
-    if (
-      !LIB_PATHS.some(libPath => file.indexOf(libPath) !== -1)
-    ) return expression;
-
-    const { name } = project.checker.getTypeAtLocation(declaration).symbol;
     const functor = METHOD_DECORATOR_PROCESSORS[name];
     if (functor === undefined) return expression;
+
+    if (!hasTransformMarker(declaration)) return expression;
+
     return functor(project, expression);
   }
 }

--- a/src/transformers/utils.ts
+++ b/src/transformers/utils.ts
@@ -40,6 +40,11 @@ import { IProject } from "../project.js";
 
 const { JSONSchemaFaker: jsf } = require("json-schema-faker");
 
+export function hasTransformMarker(node: ts.Node): boolean {
+  const jsdoc = ts.getJSDocTags(node);
+  return jsdoc.some((tag) => tag.tagName.getText() === "transformer" && tag.comment === "ts-json-schema-transformer");
+}
+
 export function getGenericArg(project: IProject, expression: ts.CallExpression): [ts.Type, ts.Node, boolean] {
   return expression.typeArguments && expression.typeArguments[0]
     ? [


### PR DESCRIPTION
Currently, the transformer errors out if source files are missing for a scanned call expression. This usually happens due to another transformer running first. The issue is that the source file information is used to verify that the node is from this library.

Instead of using source file info to determine locality, we should now use a JSDoc tag marker.