### PR TITLE
feat: assert partial valid

### DIFF
--- a/.changeset/good-turtles-smell.md
+++ b/.changeset/good-turtles-smell.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/ts-json-schema-transformer": minor
+---
+
+Renamed getValidator to getStrictValidator. Introduce new getValidator to support partial validation.

--- a/.changeset/shaggy-humans-punch.md
+++ b/.changeset/shaggy-humans-punch.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/ts-json-schema-transformer": minor
+---
+
+assertValid renamed to assertValidStrict. Introduce the new assertValid as a partial validator.

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,19 @@ export function getMockObject<T>(): T {
 
 /**
  * Assert that an object is valid according to the provided type
+ * Validates that the object has at least the properties declared in the type argument.
  * @transformer ts-json-schema-transformer
  */
 export function assertValid<T = never, U extends T = T>(_obj: unknown): asserts _obj is U {
+  throw new Error("Not implemented. Did you forget to run the transformer?");
+}
+
+/**
+ * Assert that an object is valid according to the provided type.
+ * Validates that the object has all and only the properties declared in the type argument.
+ * @transformer ts-json-schema-transformer
+ */
+export function assertValidStrict<T = never, U extends T = T>(_obj: unknown): asserts _obj is U {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,19 @@ export function getSchema<T>(): JSONSchemaType<T> {
 
 /**
  * Get a validator for the provided type
+ * Validates that the object has at least the properties declared in the type argument.
  * @transformer ts-json-schema-transformer
  */
 export function getValidator<T>(): ValidateFunction<T> {
+  throw new Error("Not implemented. Did you forget to run the transformer?");
+}
+
+/**
+ * Get a validator for the provided type
+ * Validates that the object has all and only the properties declared in the type argument.
+ * @transformer ts-json-schema-transformer
+ */
+export function getStrictValidator<T>(): ValidateFunction<T> {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,6 +1,7 @@
 import type { Options } from "ajv";
-import { Config, NodeParser, SchemaGenerator, TypeFormatter } from "ts-json-schema-generator";
+import { Config, NodeParser, TypeFormatter } from "ts-json-schema-generator";
 import * as ts from "typescript";
+import { SchemaGenerator } from "./schema-generator";
 
 export interface IProject {
   program: ts.Program;
@@ -20,7 +21,7 @@ export type AJVOptions = Pick<
 >;
 export type SchemaConfig = Pick<
   Config,
-  "sortProps" | "expose" | "jsDoc" | "strictTuples" | "encodeRefs" | "additionalProperties"
+  "sortProps" | "expose" | "jsDoc" | "strictTuples" | "encodeRefs"
 >;
 
 export const AJV_DEFAULTS: AJVOptions = {
@@ -37,7 +38,6 @@ export const SCHEMA_DEFAULTS: SchemaConfig = {
   sortProps: true,
   strictTuples: false,
   encodeRefs: true,
-  additionalProperties: false,
 };
 
 export type IOptions = AJVOptions & SchemaConfig;

--- a/src/schema-generator.ts
+++ b/src/schema-generator.ts
@@ -1,0 +1,37 @@
+import { JSONSchema7 } from "json-schema";
+import { createFormatter, createParser } from "ts-json-schema-generator";
+import { SchemaGenerator as TsJsonSchemaGenerator } from "ts-json-schema-generator";
+import ts from "typescript";
+import { SchemaConfig } from "./project";
+
+export class SchemaGenerator {
+  private readonly schemaGenerator;
+  private readonly strictSchemaGenerator;
+
+  constructor(program: ts.Program, schemaConfig: SchemaConfig) {
+    const nodeParser = createParser(program, { ...schemaConfig, additionalProperties: true });
+    const strictNodeParser = createParser(program, { ...schemaConfig, additionalProperties: false });
+    const typeFormatter = createFormatter({ ...schemaConfig });
+
+    this.schemaGenerator = new TsJsonSchemaGenerator(program, nodeParser, typeFormatter, {
+      ...schemaConfig,
+      additionalProperties: true,
+    });
+    this.strictSchemaGenerator = new TsJsonSchemaGenerator(program, strictNodeParser, typeFormatter, {
+      ...schemaConfig,
+      additionalProperties: false,
+    });
+  }
+
+  public createSchemaFromNodes(nodes: ts.Node[], additionalProperties = false) {
+    let schema: JSONSchema7;
+
+    if (additionalProperties) {
+      schema = this.schemaGenerator.createSchemaFromNodes(nodes);
+    } else {
+      schema = this.strictSchemaGenerator.createSchemaFromNodes(nodes);
+    }
+
+    return schema;
+  }
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,13 +1,13 @@
-import { createFormatter, createParser, SchemaGenerator } from "ts-json-schema-generator";
+import { createFormatter, createParser } from "ts-json-schema-generator";
 import * as ts from "typescript";
 import { AJV_DEFAULTS, AJVOptions, IOptions, IProject, SCHEMA_DEFAULTS, SchemaConfig } from "./project.js";
+import { SchemaGenerator } from "./schema-generator.js";
 import { FileTransformer } from "./transformers/file-transformer.js";
 
 export default function transform(program: ts.Program, options: IOptions = {}): ts.TransformerFactory<ts.SourceFile> {
   const {
     loopEnum,
     loopRequired,
-    additionalProperties,
     encodeRefs,
     strictTuples,
     jsDoc,
@@ -24,7 +24,6 @@ export default function transform(program: ts.Program, options: IOptions = {}): 
     jsDoc: jsDoc || SCHEMA_DEFAULTS.jsDoc,
     strictTuples: strictTuples || SCHEMA_DEFAULTS.strictTuples,
     encodeRefs: encodeRefs || SCHEMA_DEFAULTS.encodeRefs,
-    additionalProperties: additionalProperties || SCHEMA_DEFAULTS.additionalProperties,
     sortProps: sortProps || SCHEMA_DEFAULTS.sortProps,
     expose,
   };
@@ -39,14 +38,7 @@ export default function transform(program: ts.Program, options: IOptions = {}): 
     allErrors: allErrors || AJV_DEFAULTS.allErrors,
   };
 
-  const nodeParser = createParser(program, {
-    ...schemaConfig,
-  });
-  const typeFormatter = createFormatter({
-    ...schemaConfig,
-  });
-
-  const schemaGenerator = new SchemaGenerator(program, nodeParser, typeFormatter, schemaConfig);
+  const schemaGenerator = new SchemaGenerator(program, schemaConfig);
   const project: IProject = {
     checker: program.getTypeChecker(),
     options: {

--- a/src/transformers/assert-valid-transformer.ts
+++ b/src/transformers/assert-valid-transformer.ts
@@ -6,24 +6,36 @@ import { getGenericArg } from "./utils.js";
 
 export abstract class AssertValidTransformer {
   public static transform(project: IProject, expression: ts.CallExpression): ts.Node {
-    // Get the type info
-    const [type, node] = getGenericArg(project, expression);
-
-    if (type.isTypeParameter()) {
-      throw new Error(
-        `Error on getSchema: non-specified generic argument.`,
-      );
-    }
-    const schema = project.schemaGenerator.createSchemaFromNodes([node]);
-    const validatorCallExp = schemaToValidator(schema, project.options.validation);
-    const validationAssertionIdentifier = FileTransformer.getOrCreateImport(
-      expression.getSourceFile(),
-      "@nrfcloud/ts-json-schema-transformer",
-      "validationAssertion",
-    );
-    return ts.factory.createCallExpression(validationAssertionIdentifier, undefined, [
-      validatorCallExp,
-      expression.arguments[0],
-    ]);
+    return transform(project, expression, true);
   }
 }
+
+export abstract class AssertValidStrictTransformer {
+  public static transform(project: IProject, expression: ts.CallExpression): ts.Node {
+    return transform(project, expression);
+  }
+}
+
+const transform = (project: IProject, expression: ts.CallExpression, additionalProperties = false): ts.Node => {
+  // Get the type info
+  const [type, node] = getGenericArg(project, expression);
+
+  if (type.isTypeParameter()) {
+    throw new Error(
+      `Error on getSchema: non-specified generic argument.`,
+    );
+  }
+
+  const schema = project.schemaGenerator.createSchemaFromNodes([node], additionalProperties);
+
+  const validatorCallExp = schemaToValidator(schema, project.options.validation);
+  const validationAssertionIdentifier = FileTransformer.getOrCreateImport(
+    expression.getSourceFile(),
+    "@nrfcloud/ts-json-schema-transformer",
+    "validationAssertion",
+  );
+  return ts.factory.createCallExpression(validationAssertionIdentifier, undefined, [
+    validatorCallExp,
+    expression.arguments[0],
+  ]);
+};

--- a/src/transformers/call-transformer.ts
+++ b/src/transformers/call-transformer.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { IProject } from "../project.js";
-import { AssertValidTransformer } from "./assert-valid-transformer.js";
+import { AssertValidStrictTransformer, AssertValidTransformer } from "./assert-valid-transformer.js";
 import { GetMockObjectTransformer } from "./get-mock-object-transformer";
 import { GetSchemaTransformer } from "./get-schema-transformer.js";
 import { hasTransformMarker } from "./utils";
@@ -34,4 +34,5 @@ const METHOD_DECORATOR_PROCESSORS: Record<string, Task> = {
   "getValidator": ValidateTransformer.transform,
   "getMockObject": GetMockObjectTransformer.transform,
   "assertValid": AssertValidTransformer.transform,
+  "assertValidStrict": AssertValidStrictTransformer.transform,
 };

--- a/src/transformers/call-transformer.ts
+++ b/src/transformers/call-transformer.ts
@@ -4,6 +4,7 @@ import { AssertValidStrictTransformer, AssertValidTransformer } from "./assert-v
 import { GetMockObjectTransformer } from "./get-mock-object-transformer";
 import { GetSchemaTransformer } from "./get-schema-transformer.js";
 import { hasTransformMarker } from "./utils";
+import { StrictValidateTransformer } from "./validate-transformer";
 import { ValidateTransformer } from "./validate-transformer.js";
 
 export abstract class CallTransformer {
@@ -32,6 +33,7 @@ type Task = (project: IProject, expression: ts.CallExpression) => ts.Node;
 const METHOD_DECORATOR_PROCESSORS: Record<string, Task> = {
   "getSchema": GetSchemaTransformer.transform,
   "getValidator": ValidateTransformer.transform,
+  "getStrictValidator": StrictValidateTransformer.transform,
   "getMockObject": GetMockObjectTransformer.transform,
   "assertValid": AssertValidTransformer.transform,
   "assertValidStrict": AssertValidStrictTransformer.transform,

--- a/src/transformers/validate-transformer.ts
+++ b/src/transformers/validate-transformer.ts
@@ -9,16 +9,26 @@ import { getGenericArg } from "./utils.js";
  */
 export abstract class ValidateTransformer {
   public static transform(project: IProject, expression: ts.CallExpression): ts.Node {
-    // Get the type info
-    const [type, node] = getGenericArg(project, expression);
-    if (type.isTypeParameter()) {
-      throw new Error(
-        `Error on getSchema: non-specified generic argument.`,
-      );
-    }
-
-    const schema = project.schemaGenerator.createSchemaFromNodes([node]);
-
-    return schemaToValidator(schema, project.options.validation);
+    return transform(project, expression, true);
   }
 }
+
+export abstract class StrictValidateTransformer {
+  public static transform(project: IProject, expression: ts.CallExpression): ts.Node {
+    return transform(project, expression);
+  }
+}
+
+const transform = (project: IProject, expression: ts.CallExpression, additionalProperties = false): ts.Node => {
+  // Get the type info
+  const [type, node] = getGenericArg(project, expression);
+  if (type.isTypeParameter()) {
+    throw new Error(
+      `Error on getSchema: non-specified generic argument.`,
+    );
+  }
+
+  const schema = project.schemaGenerator.createSchemaFromNodes([node], additionalProperties);
+
+  return schemaToValidator(schema, project.options.validation);
+};

--- a/tests/src/assert.test.ts
+++ b/tests/src/assert.test.ts
@@ -1,20 +1,20 @@
-import { assertValid } from "@nrfcloud/ts-json-schema-transformer";
-import { ServiceURL, SimpleType } from "./types";
+import { assertValid, assertValidStrict } from "@nrfcloud/ts-json-schema-transformer";
+import { ExampleBaseType, ExampleExtendedType1, ExampleExtendedType2, ServiceURL, SimpleType } from "./types";
 
 describe("Simple Assert Test", () => {
   it("should validate a simple schema", () => {
-    expect(() => assertValid<SimpleType>({ foo: "bar" })).not.toThrowError();
-    expect(() => assertValid<ServiceURL>("http://foo.com/blah_blah")).not.toThrowError();
+    expect(() => assertValidStrict<SimpleType>({ foo: "bar" })).not.toThrowError();
+    expect(() => assertValidStrict<ServiceURL>("http://foo.com/blah_blah")).not.toThrowError();
   });
 
   it("should throw on validation error", () => {
-    expect(() => assertValid<SimpleType>("2021-01-01T00:00:00Z")).toThrowError();
-    expect(() => assertValid<ServiceURL>("http://")).toThrow();
+    expect(() => assertValidStrict<SimpleType>("2021-01-01T00:00:00Z")).toThrowError();
+    expect(() => assertValidStrict<ServiceURL>("http://")).toThrow();
   });
 
   it("should narrow type", () => {
     const fn = (obj: SimpleType | string) => {
-      assertValid<SimpleType>(obj);
+      assertValidStrict<SimpleType>(obj);
       expect(obj.foo).toBeDefined();
     };
 
@@ -23,5 +23,44 @@ describe("Simple Assert Test", () => {
     };
 
     fn(simpleType);
+  });
+
+  it("should allow for additional properties", () => {
+    const test: ExampleExtendedType1 = {
+      name: "Test",
+      lat: 41.5,
+      lon: 35.5,
+    };
+
+    const test2: ExampleExtendedType2 = {
+      name: "OtherTest",
+      description: "This is a description",
+    };
+
+    expect(() => assertValid<ExampleBaseType>(test)).not.toThrowError();
+    expect(() => assertValid<ExampleBaseType>(test2)).not.toThrowError();
+
+    expect(() => assertValid<ExampleExtendedType1>(test)).not.toThrowError();
+    expect(() => assertValid<ExampleExtendedType2>(test2)).not.toThrowError();
+
+    const fn = (obj: unknown) => {
+      assertValid<ExampleBaseType>(obj);
+      expect(obj.name).toBeDefined();
+    };
+
+    fn(test);
+  });
+
+  it("should not allow for additional properties", () => {
+    const base: ExampleBaseType = {
+      name: "Test",
+    };
+    const test: ExampleExtendedType1 = {
+      ...base,
+      lat: 41.5,
+      lon: 35.5,
+    };
+
+    expect(() => assertValidStrict<ExampleBaseType>(test)).toThrowError();
   });
 });

--- a/tests/src/types.ts
+++ b/tests/src/types.ts
@@ -80,3 +80,16 @@ export const ServiceProcessStatuses = {
 export type ServiceProcessStatus = UnionValues<typeof ServiceProcessStatuses>;
 
 export type UnionValues<T> = T[keyof T];
+
+export type ExampleBaseType = {
+  name: string;
+};
+
+export type ExampleExtendedType1 = ExampleBaseType & {
+  lat: number;
+  lon: number;
+};
+
+export type ExampleExtendedType2 = ExampleBaseType & {
+  description: string;
+};

--- a/tests/src/validator.test.ts
+++ b/tests/src/validator.test.ts
@@ -1,4 +1,4 @@
-import { getValidator } from "../../dist";
+import { getStrictValidator, getValidator } from "@nrfcloud/ts-json-schema-transformer";
 import { ISODateTime, ISOTime, SimpleType } from "./types";
 
 export interface InputEvent {
@@ -25,15 +25,17 @@ export type TenantId = string;
 describe("Validator", () => {
   describe("Simple Schema", () => {
     const validator = getValidator<SimpleType>();
+    const strictValidator = getStrictValidator<SimpleType>();
 
     it("should validate a simple schema", () => {
       expect(validator({ foo: "bar" })).toBeTruthy();
+      expect(validator({ foo: "bar", additional: "property" })).toBeTruthy();
     });
 
     it("should not validate a simple schema", () => {
-      expect(validator({ test: true })).toBeFalsy();
+      expect(strictValidator({ test: true })).toBeFalsy();
 
-      expect(validator.errors).toEqual([
+      expect(strictValidator.errors).toEqual([
         {
           instancePath: "",
           keyword: "required",
@@ -49,6 +51,21 @@ describe("Validator", () => {
           message: "must NOT have additional properties",
           params: {
             additionalProperty: "test",
+          },
+          schemaPath: "#/definitions/SimpleType/additionalProperties",
+        },
+      ]);
+    });
+
+    it("should not validate additional properties", () => {
+      expect(strictValidator({ foo: "bar", additional: "property" })).toBeFalsy();
+      expect(strictValidator.errors).toEqual([
+        {
+          instancePath: "",
+          keyword: "additionalProperties",
+          message: "must NOT have additional properties",
+          params: {
+            additionalProperty: "additional",
           },
           schemaPath: "#/definitions/SimpleType/additionalProperties",
         },


### PR DESCRIPTION
The current `assertValid` and `getValidator` method is strict by default and doesn't support the flexibility to partially validate a type.
This PR renames `assertValid` to `assertValidStrict` and `getValidator` to `getStrictValidator` to indicate that additional properties are not valid.
Introduce a new `assertValid` and `getValidator` which allows for partial validation.
This may require existing implementations of `assertValid` and `getValidator` to be changed to `assertValidStrict` and `getValidator` respectively depending on implementation.