### PR TITLE
Store ajv errors in ValidationError object

### DIFF
--- a/.changeset/yellow-baboons-rhyme.md
+++ b/.changeset/yellow-baboons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/ts-json-schema-transformer": patch
+---
+
+Automatically add AJV errors to ValidationError.cause.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
 concurrency: ${{ github.workflow }}-${{ github.ref }}
+permissions: write-all
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/slacknotify.yml
+++ b/.github/workflows/slacknotify.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
+permissions: write-all
 jobs:
   slackNotification:
     if: false

--- a/.github/workflows/stop-no-merge-labels.yml
+++ b/.github/workflows/stop-no-merge-labels.yml
@@ -3,7 +3,7 @@ name: Block merging PRs with 'no-merge' label
 on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
-
+permissions: write-all
 jobs:
   no-merge:
     if: ${{ contains(github.event.*.labels.*.name, 'no-merge') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
-
+permissions: write-all
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,9 @@ export class ValidationError extends Error {
  */
 export function validationAssertion(validator: ValidateFunction<unknown>, obj: unknown) {
   if (!validator(obj)) {
-    throw new ValidationError(`Validation error: ${validator.errors?.map(error => JSON.stringify(error)).join(", ")}`);
+    throw new ValidationError(`Validation error: ${validator.errors?.map(error => JSON.stringify(error)).join(", ")}`, {
+      cause: validator.errors,
+    });
   }
   return obj;
 }

--- a/tests/src/assert.test.ts
+++ b/tests/src/assert.test.ts
@@ -26,13 +26,20 @@ describe("Simple Assert Test", () => {
   });
 
   it("should throw ValidationError object", () => {
-    let err;
     try {
       assertValid<SimpleType>("2021-01-01T00:00:00Z");
-    } catch (error) {
-      err = error;
-    } finally {
-      expect(err).toBeInstanceOf(ValidationError);
+    } catch (e) {
+      const error = e as ValidationError;
+      expect(error).toBeInstanceOf(ValidationError);
+      expect(error.cause).toEqual([
+        {
+          instancePath: "",
+          schemaPath: "#/definitions/SimpleType/type",
+          keyword: "type",
+          params: { type: "object" },
+          message: "must be object",
+        },
+      ]);
     }
   });
 });


### PR DESCRIPTION
We want to prettify AJV errors in our HTTP error responses, but we need the AJV errors array to pass to [a lib like this](https://github.com/atlassian/better-ajv-errors?tab=readme-ov-file#betterajverrorsschema-data-errors-options).