### PR TITLE
Seeded mock and assert with return

### DIFF
--- a/.changeset/grumpy-ants-know.md
+++ b/.changeset/grumpy-ants-know.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/ts-json-schema-transformer": minor
+---
+
+seeded mock

--- a/README.md
+++ b/README.md
@@ -141,14 +141,19 @@ Generates an AJV validator function for the given type.
 The generic type parameter is the type you want to generate a validator for, and the single input to the function.
 This function call is replaced by the generated validator at compile time.
 
-#### `getMockObject<T>(): T`
+#### `getMockObject<T, Seed>(): T`
 
 Generate a mock object for the given type.
 Should support all formats as well as other constraints.
+You can optionally specify a seed for the random number generator as the second parameter.
 
 #### `assertValid<T>(obj: unknown): asserts obj is T`
 
 Validates that a given object satisfies the constraints defined in the given generic type parameter's schema. The method will throw an error if validation fails. This function call is replaced a wrapped validator method at compile time.
+
+#### `assert<T>(obj: unknown): T`
+
+Very similar to `assertValid` but returns the passed object instead of narrowing the type.
 
 ### JSDoc Tags
 
@@ -394,6 +399,10 @@ Note that not all options are exposed, though more could be added in the future.
         
         // Whether properties should be sorted (stable)
         "sortProps": true,
+        
+        // Explicitly set the seed used for mock data generation.
+        // You can disable seeding by setting this false
+        "seed": "this is a seed"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/jest": "^29.5.11",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^18.19.3",
+    "@types/seedrandom": "^3.0.8",
     "dprint": "^0.35.4",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
@@ -84,7 +85,8 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "ajv": "^8.12.0",
     "esbuild": "^0.23.0",
-    "json-schema-faker": "npm:@jfconley/json-schema-faker@0.5.0-rcv.48",
+    "json-schema-faker": "^0.5.6",
+    "seedrandom": "^3.0.5",
     "ts-json-schema-generator": "^2.4.0-next.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,11 @@ importers:
         specifier: ^0.23.0
         version: 0.23.0
       json-schema-faker:
-        specifier: npm:@jfconley/json-schema-faker@0.5.0-rcv.48
-        version: '@jfconley/json-schema-faker@0.5.0-rcv.48'
+        specifier: ^0.5.6
+        version: 0.5.6
+      seedrandom:
+        specifier: ^3.0.5
+        version: 3.0.5
       ts-json-schema-generator:
         specifier: ^2.4.0-next.2
         version: 2.4.0-next.2
@@ -45,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^18.19.3
         version: 18.19.3
+      '@types/seedrandom':
+        specifier: ^3.0.8
+        version: 3.0.8
       dprint:
         specifier: ^0.35.4
         version: 0.35.4
@@ -72,10 +78,6 @@ packages:
   '@ampproject/remapping@2.2.1':
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
-
-  '@apidevtools/json-schema-ref-parser@10.1.0':
-    resolution: {integrity: sha512-3e+viyMuXdrcK8v5pvP+SDoAQ77FH6OyRmuK48SZKmdHJRFm87RsSs8qm6kP39a/pOPURByJw+OXzQIqcfmKtA==}
-    engines: {node: '>= 16'}
 
   '@apidevtools/json-schema-ref-parser@11.7.0':
     resolution: {integrity: sha512-pRrmXMCwnmrkS3MLgAIW5dXRzeTv6GLjkjb4HmxNnvAKXN1Nfzp4KmGADBQvlVUcqi+a5D+hfGDLLnd5NnYxog==}
@@ -957,10 +959,6 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jfconley/json-schema-faker@0.5.0-rcv.48':
-    resolution: {integrity: sha512-n5I703+lUEDqXEmwJ7MUcBzpoYX+MJK9grhn65kqUHNNm0aPN5qr88zXchrybkZCkig8tp7GF++HOgjLazV6rA==}
-    hasBin: true
-
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -1126,12 +1124,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/lodash.clonedeep@4.5.9':
-    resolution: {integrity: sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==}
-
-  '@types/lodash@4.14.202':
-    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
-
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
@@ -1143,6 +1135,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/seedrandom@3.0.8':
+    resolution: {integrity: sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==}
 
   '@types/semver@7.5.6':
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
@@ -1304,6 +1299,9 @@ packages:
 
   call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1607,6 +1605,9 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  format-util@1.0.5:
+    resolution: {integrity: sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2078,6 +2079,14 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-faker@0.5.6:
+    resolution: {integrity: sha512-u/cFC26/GDxh2vPiAC8B8xVvpXAW+QYtG2mijEbKrimCk8IHtiwQBjCE8TwvowdhALWq9IcdIWZ+/8ocXvdL3Q==}
+    hasBin: true
+
+  json-schema-ref-parser@6.1.0:
+    resolution: {integrity: sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==}
+    deprecated: Please switch to @apidevtools/json-schema-ref-parser
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -2092,9 +2101,9 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
-  jsonpath-plus@5.1.0:
-    resolution: {integrity: sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ==}
-    engines: {node: '>=10.0.0'}
+  jsonpath-plus@7.2.0:
+    resolution: {integrity: sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==}
+    engines: {node: '>=12.0.0'}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -2126,9 +2135,6 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
-
-  lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -2254,6 +2260,9 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  ono@4.0.11:
+    resolution: {integrity: sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==}
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -2471,6 +2480,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -2865,14 +2877,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
-
-  '@apidevtools/json-schema-ref-parser@10.1.0':
-    dependencies:
-      '@jsdevtools/ono': 7.1.3
-      '@types/json-schema': 7.0.15
-      '@types/lodash.clonedeep': 4.5.9
-      js-yaml: 4.1.0
-      lodash.clonedeep: 4.5.0
 
   '@apidevtools/json-schema-ref-parser@11.7.0':
     dependencies:
@@ -4018,11 +4022,6 @@ snapshots:
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
-  '@jfconley/json-schema-faker@0.5.0-rcv.48':
-    dependencies:
-      json-schema-ref-parser: '@apidevtools/json-schema-ref-parser@10.1.0'
-      jsonpath-plus: 5.1.0
-
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
@@ -4183,12 +4182,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/lodash.clonedeep@4.5.9':
-    dependencies:
-      '@types/lodash': 4.14.202
-
-  '@types/lodash@4.14.202': {}
-
   '@types/minimist@1.2.5': {}
 
   '@types/node@12.20.55': {}
@@ -4198,6 +4191,8 @@ snapshots:
       undici-types: 5.26.5
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/seedrandom@3.0.8': {}
 
   '@types/semver@7.5.6': {}
 
@@ -4402,6 +4397,8 @@ snapshots:
       function-bind: 1.1.2
       get-intrinsic: 1.2.2
       set-function-length: 1.1.1
+
+  call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
@@ -4765,6 +4762,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
+
+  format-util@1.0.5: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -5416,6 +5415,17 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-faker@0.5.6:
+    dependencies:
+      json-schema-ref-parser: 6.1.0
+      jsonpath-plus: 7.2.0
+
+  json-schema-ref-parser@6.1.0:
+    dependencies:
+      call-me-maybe: 1.0.2
+      js-yaml: 3.14.1
+      ono: 4.0.11
+
   json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
@@ -5430,7 +5440,7 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonpath-plus@5.1.0: {}
+  jsonpath-plus@7.2.0: {}
 
   kind-of@6.0.3: {}
 
@@ -5456,8 +5466,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash.clonedeep@4.5.0: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -5578,6 +5586,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  ono@4.0.11:
+    dependencies:
+      format-util: 1.0.5
 
   open@8.4.2:
     dependencies:
@@ -5781,6 +5793,8 @@ snapshots:
   safe-stable-stringify@2.4.3: {}
 
   safer-buffer@2.1.2: {}
+
+  seedrandom@3.0.5: {}
 
   semver@5.7.2: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function getValidator<T>(): ValidateFunction<T> {
  * Get a mock object for the provided type
  * @transformer ts-json-schema-transformer
  */
-export function getMockObject<T>(): T {
+export function getMockObject<T, const S extends string = "none">(): IfEquals<S, string, never, T> {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }
 
@@ -29,6 +29,14 @@ export function getMockObject<T>(): T {
  * @transformer ts-json-schema-transformer
  */
 export function assertValid<T = never, U extends T = T>(_obj: unknown): asserts _obj is U {
+  throw new Error("Not implemented. Did you forget to run the transformer?");
+}
+
+/**
+ * Assert that an object is valid and returns the object back
+ * @transformer ts-json-schema-transformer
+ */
+export function assert<T = never, U extends T = T>(_obj: unknown): U {
   throw new Error("Not implemented. Did you forget to run the transformer?");
 }
 
@@ -46,3 +54,8 @@ export function validationAssertion(validator: ValidateFunction<unknown>, obj: u
   }
   return obj;
 }
+
+type Exact<T, U> = IfEquals<T, U, T, never>;
+type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 : 2) extends (<G>() => G extends U ? 1 : 2) ? Y
+  : N;
+type NotAny<T> = 0 extends (1 & T) ? never : T;

--- a/src/project.ts
+++ b/src/project.ts
@@ -7,6 +7,9 @@ export interface IProject {
   options: {
     schema: SchemaConfig;
     validation: AJVOptions;
+    mock: {
+      seed: string | false;
+    };
   };
   checker: ts.TypeChecker;
   schemaGenerator: SchemaGenerator;
@@ -22,6 +25,8 @@ export type SchemaConfig = Pick<
   Config,
   "sortProps" | "expose" | "jsDoc" | "strictTuples" | "encodeRefs" | "additionalProperties"
 >;
+
+export const DEFAULT_SEED = "emerson";
 
 export const AJV_DEFAULTS = {
   useDefaults: true,
@@ -48,4 +53,6 @@ export const SCHEMA_DEFAULTS = {
   functions: "fail",
 } as const satisfies Config;
 
-export type IOptions = AJVOptions & SchemaConfig;
+export type IOptions = AJVOptions & SchemaConfig & {
+  seed?: string | false;
+};

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,6 @@
 import { createFormatter, createParser, SchemaGenerator, ts as schemaGeneratorTs } from "ts-json-schema-generator";
 import * as ts from "typescript";
-import { AJV_DEFAULTS, IOptions, IProject, SCHEMA_DEFAULTS } from "./project.js";
+import { AJV_DEFAULTS, DEFAULT_SEED, IOptions, IProject, SCHEMA_DEFAULTS } from "./project.js";
 import { FileTransformer } from "./transformers/file-transformer.js";
 
 export default function transform(program: ts.Program, options: IOptions = {}): ts.TransformerFactory<ts.SourceFile> {
@@ -16,6 +16,7 @@ export default function transform(program: ts.Program, options: IOptions = {}): 
     allErrors,
     sortProps,
     expose,
+    seed,
   } = options ?? {};
 
   const schemaConfig = {
@@ -53,6 +54,9 @@ export default function transform(program: ts.Program, options: IOptions = {}): 
   const project: IProject = {
     checker: program.getTypeChecker(),
     options: {
+      mock: {
+        seed: seed ?? DEFAULT_SEED,
+      },
       schema: schemaConfig,
       validation: validationConfig,
     },

--- a/src/transformers/call-transformer.ts
+++ b/src/transformers/call-transformer.ts
@@ -30,4 +30,5 @@ const METHOD_DECORATOR_PROCESSORS: Record<string, Task> = {
   "getValidator": ValidateTransformer.transform,
   "getMockObject": GetMockObjectTransformer.transform,
   "assertValid": AssertValidTransformer.transform,
+  "assert": AssertValidTransformer.transform,
 };

--- a/src/transformers/get-mock-object-transformer.ts
+++ b/src/transformers/get-mock-object-transformer.ts
@@ -1,16 +1,21 @@
 import { JSONSchema7 } from "json-schema";
 
-const { JSONSchemaFaker: jsf } = require("json-schema-faker");
+import seedrandom from "seedrandom";
 import { ts as schemaGeneratorTs } from "ts-json-schema-generator";
 import * as ts from "typescript";
 import { IProject } from "../project.js";
 import { addFormatsJsf, convertValueToExpression, derefJSONSchemaRoot, getGenericArg } from "./utils.js";
+
+// @ts-expect-error Using an esm type import
+type jsf = import("json-schema-faker");
+const jsf = require("json-schema-faker");
 
 addFormatsJsf();
 
 export abstract class GetMockObjectTransformer {
   public static transform(project: IProject, expression: ts.CallExpression): ts.Node {
     const [type, node] = getGenericArg(project, expression);
+    const [, seedNode, seedProvided] = getGenericArg(project, expression, 1);
 
     if (type.isTypeParameter()) {
       throw new Error(
@@ -18,8 +23,19 @@ export abstract class GetMockObjectTransformer {
       );
     }
 
-    const schema = derefJSONSchemaRoot(project.schemaGenerator.createSchemaFromNodes([node as schemaGeneratorTs.Node]));
+    let specifiedSeed: string | undefined = undefined;
+    if (
+      seedProvided && seedNode != undefined && ts.isLiteralTypeNode(seedNode) && ts.isStringLiteral(seedNode.literal)
+    ) {
+      specifiedSeed = seedNode.literal.text;
+    }
+    if (project.options.mock.seed !== false || specifiedSeed) {
+      jsf.option("random", seedrandom(project.options.mock.seed || specifiedSeed));
+    } else {
+      jsf.option("random", Math.random);
+    }
 
+    const schema = derefJSONSchemaRoot(project.schemaGenerator.createSchemaFromNodes([node as schemaGeneratorTs.Node]));
     return convertValueToExpression(jsf.generate(schema as JSONSchema7));
   }
 }

--- a/src/transformers/utils.ts
+++ b/src/transformers/utils.ts
@@ -45,20 +45,20 @@ export function hasTransformMarker(node: ts.Node): boolean {
   return jsdoc.some((tag) => tag.tagName.getText() === "transformer" && tag.comment === "ts-json-schema-transformer");
 }
 
-export function getGenericArg(project: IProject, expression: ts.CallExpression): [ts.Type, ts.Node, boolean] {
+export function getGenericArg(project: IProject, expression: ts.CallExpression, idx = 0): [ts.Type, ts.Node, boolean] {
   return expression.typeArguments && expression.typeArguments[0]
     ? [
       project.checker.getTypeFromTypeNode(
-        expression.typeArguments[0],
+        expression.typeArguments[idx],
       ),
-      expression.typeArguments[0],
+      expression.typeArguments[idx],
       true,
     ]
     : [
       project.checker.getTypeAtLocation(
-        expression.arguments[0]!,
+        expression.arguments[idx]!,
       ),
-      expression.arguments[0]!,
+      expression.arguments[idx]!,
       false,
     ];
 }

--- a/tests/src/assert.test.ts
+++ b/tests/src/assert.test.ts
@@ -1,4 +1,4 @@
-import { assertValid, ValidationError } from "@nrfcloud/ts-json-schema-transformer";
+import { assert, assertValid, ValidationError } from "@nrfcloud/ts-json-schema-transformer";
 import { ServiceURL, SimpleType } from "./types";
 
 describe("Simple Assert Test", () => {
@@ -41,5 +41,11 @@ describe("Simple Assert Test", () => {
         },
       ]);
     }
+  });
+
+  it("Should assert and return object", () => {
+    const test = { foo: "bar" };
+    const result = assert<SimpleType>(test);
+    expect(test).toMatchObject(result);
   });
 });

--- a/tests/src/mock.test.ts
+++ b/tests/src/mock.test.ts
@@ -1,5 +1,14 @@
 import { getMockObject, getValidator } from "@nrfcloud/ts-json-schema-transformer";
-import { ISODateTime, ISOTime, ServiceProcessStatus, SimpleType, TenantId, ULID, UnionType } from "./types";
+import {
+  ComplexType,
+  ISODateTime,
+  ISOTime,
+  ServiceProcessStatus,
+  SimpleType,
+  TenantId,
+  ULID,
+  UnionType,
+} from "./types";
 
 describe("Mock Objects", () => {
   describe("Simple Mocks", () => {
@@ -63,6 +72,22 @@ describe("Mock Objects", () => {
       const validator = getValidator<TenantId>();
 
       expect(validator(mock)).toBeTruthy();
+    });
+  });
+
+  describe("Seeds", () => {
+    it("should generate two different objects with no seed", () => {
+      const test1 = getMockObject<ComplexType>();
+      const test2 = getMockObject<ComplexType>();
+
+      expect(test1).not.toMatchObject(test2);
+    });
+
+    it("should generate two identical object with a seed", () => {
+      const test1 = getMockObject<ComplexType, "coolseed">();
+      const test2 = getMockObject<ComplexType, "coolseed">();
+
+      expect(test1).toMatchObject(test2);
     });
   });
 });

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     "plugins": [
       {
-        "transform": "../dist/transform.js"
+        "transform": "../dist/transform.js",
+        "seed": false,
       }
     ],
     "types": [


### PR DESCRIPTION
Allow specifying seeds for generated mocks. Mocks are now seeded by default to boost reliability.

Also, added a version of assert that returns the object instead of just narrowing the type.