### PR TITLE
Add default export

### DIFF
--- a/.changeset/quick-tomatoes-buy.md
+++ b/.changeset/quick-tomatoes-buy.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/ts-json-schema-transformer": minor
+---
+
+Add default export

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,3 +211,25 @@ type Exact<T, U> = IfEquals<T, U, T, never>;
 type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 : 2) extends (<G>() => G extends U ? 1 : 2) ? Y
   : N;
 type NotAny<T> = 0 extends (1 & T) ? never : T;
+
+export default {
+  getSchema,
+  validate,
+  createValidateFn,
+  guard,
+  createGuardFn,
+  createValidator,
+  getMockObject,
+  mock,
+  createMockFn,
+  assertValid,
+  assertGuard,
+  createAssertGuardFn,
+  assert,
+  createAssertFn,
+  parse,
+  createParseFn,
+  assertParse,
+  createAssertParseFn,
+  ValidationError,
+};

--- a/tests/src/rebound.test.ts
+++ b/tests/src/rebound.test.ts
@@ -1,32 +1,63 @@
-import * as tjs from "@nrfcloud/ts-json-schema-transformer";
+import * as tjs_wildcard from "@nrfcloud/ts-json-schema-transformer";
+import tjs_default from "@nrfcloud/ts-json-schema-transformer";
+
 import { SimpleType } from "./types";
 
 describe("Rebound calls", () => {
   describe("Wildcard import", () => {
     it("should not throw on assert", () => {
-      expect(() => tjs.assert<string>("")).not.toThrowError();
+      expect(() => tjs_wildcard.assert<string>("")).not.toThrowError();
     });
 
     it("should not throw on assertGuard", () => {
-      expect(() => tjs.assertGuard<string>("")).not.toThrowError();
+      expect(() => tjs_wildcard.assertGuard<string>("")).not.toThrowError();
     });
 
     it("Should validate a simple schema", () => {
-      const isValid = tjs.guard<SimpleType>({ foo: "bar" });
+      const isValid = tjs_wildcard.guard<SimpleType>({ foo: "bar" });
       expect(isValid).toBe(true);
     });
 
     it("Should invalidate a simple schema", () => {
-      const isValid = tjs.guard<SimpleType>({ test: true });
+      const isValid = tjs_wildcard.guard<SimpleType>({ test: true });
       expect(isValid).toBe(false);
     });
 
     it("Should invalidate a simple schema with an inline call", () => {
-      expect(tjs.guard<SimpleType>({ test: true })).toBe(false);
+      expect(tjs_wildcard.guard<SimpleType>({ test: true })).toBe(false);
     });
 
     it("Should create a validator", () => {
-      const validator = tjs.createGuardFn<SimpleType>();
+      const validator = tjs_wildcard.createGuardFn<SimpleType>();
+      expect(validator({ foo: "bar" })).toBe(true);
+    });
+  });
+
+  describe("Default import", () => {
+    it("should not throw on assert", () => {
+      expect(() => tjs_default.assert<string>("")).not.toThrowError();
+    });
+
+    it("should not throw on assertGuard", () => {
+      expect(() => tjs_default.assertGuard<string>("")).not.toThrowError();
+    });
+
+    it("Should validate a simple schema", () => {
+      const isValid = tjs_default.guard<SimpleType>({ foo: "bar" });
+      expect(isValid).toBe(true);
+    });
+
+    it("Should invalidate a simple schema", () => {
+      const isValid = tjs_default.guard<SimpleType>({ test: true });
+      expect(isValid).toBe(false);
+    });
+
+    it("Should invalidate a simple schema with an inline call", () => {
+      expect(tjs_default.guard<SimpleType>({ test: true })).toBe(false);
+    });
+
+    it("Should create a validator", () => {
+      const validator = tjs_default.createGuardFn<SimpleType>();
       expect(validator({ foo: "bar" })).toBe(true);
     });
   });


### PR DESCRIPTION
Default export gives a convenient way to import the api without polluting the local namespace. This is just for convenience