### PR TITLE
Fix back compat

### DIFF
--- a/.changeset/proud-bees-end.md
+++ b/.changeset/proud-bees-end.md
@@ -1,0 +1,5 @@
+---
+"@nrfcloud/ts-json-schema-transformer": patch
+---
+
+fix back compat with older runtimes

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,19 @@ export function noop(arg: unknown) {
   return arg;
 }
 
+/**
+ * @internal
+ * @deprecated
+ */
+export function validationAssertion(validator: ValidateFunction<unknown>, obj: unknown) {
+  if (!validator(obj)) {
+    throw new ValidationError(`Validation error: ${validator.errors?.map(error => JSON.stringify(error)).join(", ")}`, {
+      cause: validator.errors,
+    });
+  }
+  return obj;
+}
+
 type Exact<T, U> = IfEquals<T, U, T, never>;
 type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 : 2) extends (<G>() => G extends U ? 1 : 2) ? Y
   : N;


### PR DESCRIPTION
An internal functions used at runtime was removed, breaking packages that use this as a peer dep.

Add back the deprecated internal function to support backwards compatibility